### PR TITLE
Dunification

### DIFF
--- a/__tests__/Relude_ContT_test.re
+++ b/__tests__/Relude_ContT_test.re
@@ -10,7 +10,7 @@ module Error = {
   type t =
     | Error(string);
 
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };
@@ -18,7 +18,7 @@ module Error = {
 module Unit = {
   type t = unit;
 
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_Free_Applicative_test.re
+++ b/__tests__/Relude_Free_Applicative_test.re
@@ -21,7 +21,7 @@ module Field = {
       validator: validator >> Result.map(f),
     };
 
-  module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+  module Functor: Bastet.Interface.FUNCTOR with type t('a) = t('a) = {
     type nonrec t('a) = t('a);
     let map = map;
   };

--- a/__tests__/Relude_Free_Monad_test.re
+++ b/__tests__/Relude_Free_Monad_test.re
@@ -19,11 +19,11 @@ module StorageF = {
     };
 
   module WithKeyAndValue =
-         (K: BsBastet.Interface.TYPE, V: BsBastet.Interface.TYPE) => {
+         (K: Bastet.Interface.TYPE, V: Bastet.Interface.TYPE) => {
     type nonrec t('a) = t(K.t, V.t, 'a);
 
     // With the key/value types locked-in, we can define our functor
-    module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+    module Functor: Bastet.Interface.FUNCTOR with type t('a) = t('a) = {
       type nonrec t('a) = t('a);
       let map = map;
     };

--- a/__tests__/Relude_Function_test.re
+++ b/__tests__/Relude_Function_test.re
@@ -4,7 +4,7 @@ open Expect;
 module Function = Relude_Function;
 module StringArgument = {
   type t = string;
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_IO_test.re
+++ b/__tests__/Relude_IO_test.re
@@ -3418,7 +3418,7 @@ let eGet = e => EGet(e);
 let eParse = e => EParse(e);
 let ePrint = e => EPrint(e);
 
-module AppErrorType: BsBastet.Interface.TYPE with type t = appError = {
+module AppErrorType: Bastet.Interface.TYPE with type t = appError = {
   type t = appError;
 };
 module IOAppError = IO.WithError(AppErrorType);
@@ -3484,7 +3484,7 @@ describe("IO realish examples", () => {
 
 let testFilePath = FS.testFilePath("Eff_test.txt");
 
-module JsExnType: BsBastet.Interface.TYPE with type t = Js.Exn.t = {
+module JsExnType: Bastet.Interface.TYPE with type t = Js.Exn.t = {
   type t = Js.Exn.t;
 };
 module IOJsExn = IO.WithError(JsExnType);

--- a/__tests__/Relude_ResultT_test.re
+++ b/__tests__/Relude_ResultT_test.re
@@ -9,7 +9,7 @@ type error = {message: string};
 
 module Error = {
   type t = error;
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/Relude_Validation_test.re
+++ b/__tests__/Relude_Validation_test.re
@@ -14,7 +14,7 @@ module Error = {
     | InvalidLanguage(string);
 
   // This is used below to create the Apply instance for the Validation
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/__tests__/extensions/Relude_Extensions_Enum_test.re
+++ b/__tests__/extensions/Relude_Extensions_Enum_test.re
@@ -48,21 +48,21 @@ module Month = {
     | 12 => Some(Dec)
     | _ => None;
 
-  module Eq: BsBastet.Interface.EQ with type t = t =
+  module Eq: Bastet.Interface.EQ with type t = t =
     Int.EqBy({
       type a = t;
       type b = int;
       let f = toInt1Based;
     });
 
-  module Ord: BsBastet.Interface.ORD with type t = t =
+  module Ord: Bastet.Interface.ORD with type t = t =
     Int.OrdBy({
       type a = t;
       type b = int;
       let f = toInt1Based;
     });
 
-  module Bounded: BsBastet.Interface.BOUNDED with type t = t = {
+  module Bounded: Bastet.Interface.BOUNDED with type t = t = {
     include Ord;
     let bottom = Jan;
     let top = Dec;
@@ -85,7 +85,7 @@ module Month = {
     let fromEnum = toInt1Based;
   };
 
-  module Show: BsBastet.Interface.SHOW with type t = t = {
+  module Show: Bastet.Interface.SHOW with type t = t = {
     type nonrec t = t;
     let show: t => string =
       fun

--- a/__tests__/extensions/Relude_Extensions_Ord_test.re
+++ b/__tests__/extensions/Relude_Extensions_Ord_test.re
@@ -1,7 +1,7 @@
 open Jest;
 open Expect;
 open! Relude.Globals;
-open BsBastet.Interface;
+open Bastet.Interface;
 
 module User = {
   type t = {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -19,15 +19,15 @@ We use peer dependencies in all `Relude` libraries, so that the top-level host l
 
 `Relude` also has many of its own types, which have their own modules, like `Relude.AsyncResult`, `Relude.ReaderT`, etc.
 
-## I'm getting strange errors about types like `array(string)` not being the same as `BsBastet.Array.Foldable.t`
+## I'm getting strange errors about types like `array(string)` not being the same as `Bastet.Array.Foldable.t`
 
 If you are trying to compile and get an error like:
 
 ```reasonml
-This has type array(t) but somewhere wanted BsBastet.Array.Foldable.t(string)`
+This has type array(t) but somewhere wanted Bastet.Array.Foldable.t(string)`
 ```
 
-you likely need to add `bs-bastet` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because Melange is not able to find the types defined in the `BsBastet` module, so it can't determine that `array(t)` is the same type as `BsBastet.Array.Foldable.t(string)`.
+you likely need to add `bs-bastet` to your `bs-dependencies` in your `bsconfig.json` file.  This error occurs because Melange is not able to find the types defined in the `Bastet_js` module, so it can't determine that `array(t)` is the same type as `Bastet.Array.Foldable.t(string)`.
 
 Because we are not using .rei interface files, we are not able to abstract these types away for functions that get included into our implementation modules.  (See .rei topic below).
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -22,7 +22,7 @@ Also, building our own standard library allows us to build out a set of addition
 
 ## Typeclass module types (interfaces)
 
-`Relude` uses many of the typeclass interface definitions and implementations provided by `bs-bastet`, while also adding some of it's own typeclasses.  Using the typeclass module types from [BsBastet.Interface](https://github.com/Risto-Stevcev/bastet/blob/master/bastet/src/Interface.re) allows us to gain compatibility with any other libraries which happen to use the same typeclass signatures "for free."  E.g. if something implements a `MONAD` in another library, it should be compatible with any of the utiltiies provided by `Relude`, which use the `MONAD` module type.
+`Relude` uses many of the typeclass interface definitions and implementations provided by `bs-bastet`, while also adding some of it's own typeclasses.  Using the typeclass module types from [Bastet.Interface](https://github.com/Risto-Stevcev/bastet/blob/master/bastet/src/Interface.re) allows us to gain compatibility with any other libraries which happen to use the same typeclass signatures "for free."  E.g. if something implements a `MONAD` in another library, it should be compatible with any of the utiltiies provided by `Relude`, which use the `MONAD` module type.
 
 ## Typeclass modules (instances or implementations)
 
@@ -30,7 +30,7 @@ Also, building our own standard library allows us to build out a set of addition
 
 ## Extensions and infix operators
 
-Using typeclass-style abstractions allows us to provide a ton of extra functionality "for free" for many modules.  For example, for any module that has an implementation of the module type `BsBastet.Interface.MONAD`, we can `include` a wide variety of extension functions and infix operators for free for that module, all implemented consistently and predictably.  If you've ever found yourself implementing `map2`, `flatten`, `length`, `toArray`, etc. for your types, it's likely that you could instead get these functions for free by implementing the corresponding typeclass.
+Using typeclass-style abstractions allows us to provide a ton of extra functionality "for free" for many modules.  For example, for any module that has an implementation of the module type `Bastet.Interface.MONAD`, we can `include` a wide variety of extension functions and infix operators for free for that module, all implemented consistently and predictably.  If you've ever found yourself implementing `map2`, `flatten`, `length`, `toArray`, etc. for your types, it's likely that you could instead get these functions for free by implementing the corresponding typeclass.
 
 ## IO
 

--- a/dune
+++ b/dune
@@ -1,36 +1,4 @@
-; (dirs :standard __tests__)
-; (subdir
-;  node_modules
-;  (dirs reason-react)
-;  (vendored_dirs reason-react)
-;  (subdir
-;   reason-react/src
-;   (include_subdirs unqualified)
-;   (library
-;    (name reason_react)
-;    (wrapped false)
-;    (modes melange))))
-
-; (data_only_dirs node_modules)
-
-(subdir
- node_modules
- (data_only_dirs bs-bastet))
-
-(subdir
- node_modules/bs-bastet/bastet/src
- ; (dirs bs-bastet)
- ; (data_only_dirs bs-bastet)
- ; (subdir
- ;  bs-bastet/bastet/src
- ; (copy_files# ../../bastet_js/src/*.ml{,i})
- (library
-  (name bsBastet)
-  (modes melange)
-  (flags -w -67)))
-
 (melange.emit
  (target output)
  (alias relude)
- (libraries melange bsBastet)
  (module_systems es6))

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "docsify-cli": "~4.4.0"
   },
   "dependencies": {
-    "bs-bastet": "jchavarri/bastet#melange",
     "bisect_ppx": "^2.7.1"
   },
   "jest": {

--- a/relude.opam
+++ b/relude.opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {dev}
   "melange-compiler-libs" {dev}
   "melange" {dev}
+  "bastet" {dev}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -37,4 +38,5 @@ pin-depends: [
   [ "dune.dev" "git+https://github.com/ocaml/dune.git#66573762f28b84268cf04c3c46d0deaef9945316" ]
   [ "melange-compiler-libs.dev" "git+https://github.com/melange-re/melange-compiler-libs.git#7263bea2285499f5da857f2bb374345a5178791e" ]
   [ "melange.dev" "git+https://github.com/melange-re/melange.git#4df18aaa5468391c4b190ebc5d4c3ba38698a565" ]
+  [ "bastet.dev" "git+https://github.com/jchavarri/bastet.git#501134d7377d066542bc80bc3b56463e7af1ffdc" ]
 ]

--- a/src/Relude_AsyncData.re
+++ b/src/Relude_AsyncData.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_AsyncResult.re
+++ b/src/Relude_AsyncResult.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_Bool.re
+++ b/src/Relude_Bool.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_ContT.re
+++ b/src/Relude_ContT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Creates a ContT (continuation) Monad module with the given Monad module.

--- a/src/Relude_Eq.re
+++ b/src/Relude_Eq.re
@@ -26,7 +26,7 @@ let by: 'a 'b. ('b => 'a, eq('a)) => eq('b) =
 let cmap = by;
 
 module Contravariant:
-  BsBastet.Interface.CONTRAVARIANT with type t('a) = eq('a) = {
+  Bastet.Interface.CONTRAVARIANT with type t('a) = eq('a) = {
   type t('a) = eq('a);
   let cmap = cmap;
 };

--- a/src/Relude_Float.re
+++ b/src/Relude_Float.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|
@@ -114,7 +114,7 @@ let isNaN: float => bool = x => x != x;
 /**
 Compates two floats
 */
-let compare: (float, float) => ordering = BsBastet.Float.Ord.compare;
+let compare: (float, float) => ordering = Bastet.Float.Ord.compare;
 
 module Ord: ORD with type t = float = {
   include Eq;
@@ -288,21 +288,21 @@ let fromString: string => option(float) =
     };
 
 module Additive = {
-  include BsBastet.Float.Additive;
+  include Bastet.Float.Additive;
 };
 
 module Multiplicative = {
-  include BsBastet.Float.Multiplicative;
+  include Bastet.Float.Multiplicative;
 };
 
 module Subtractive = {
-  include BsBastet.Float.Subtractive;
+  include Bastet.Float.Subtractive;
 };
 
 module Divisive = {
-  include BsBastet.Float.Divisive;
+  include Bastet.Float.Divisive;
 };
 
 module Infix = {
-  include BsBastet.Float.Infix;
+  include Bastet.Float.Infix;
 };

--- a/src/Relude_Free_Applicative.re
+++ b/src/Relude_Free_Applicative.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 module WithFunctor = (F: FUNCTOR) => {

--- a/src/Relude_Free_Monad.re
+++ b/src/Relude_Free_Monad.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 module WithFunctor = (F: FUNCTOR) => {
   type t('a) =

--- a/src/Relude_Function.re
+++ b/src/Relude_Function.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_IO.re
+++ b/src/Relude_IO.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 [@ocaml.text

--- a/src/Relude_Identity.re
+++ b/src/Relude_Identity.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_Int.re
+++ b/src/Relude_Int.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|
@@ -122,7 +122,7 @@ let rec rangeAsArray: (int, int) => array(int) =
 /**
 [eq(a, b)] returns [true] if the arguments are equal, [false] otherwise.
 */
-let eq: (int, int) => bool = BsBastet.Int.Eq.eq;
+let eq: (int, int) => bool = Bastet.Int.Eq.eq;
 
 module Eq: EQ with type t = int = {
   type t = int;
@@ -141,7 +141,7 @@ two ints are the same.
   Int.compare(5, 3) == `greater_than;
 ]}
 */
-let compare: (int, int) => ordering = BsBastet.Int.Ord.compare;
+let compare: (int, int) => ordering = Bastet.Int.Ord.compare;
 
 module Ord: ORD with type t = int = {
   include Eq;
@@ -254,23 +254,23 @@ let fromString: string => option(int) =
     };
 
 module Additive = {
-  include BsBastet.Int.Additive;
+  include Bastet.Int.Additive;
 };
 
 module Multiplicative = {
-  include BsBastet.Int.Multiplicative;
+  include Bastet.Int.Multiplicative;
 };
 
 module Subtractive = {
-  include BsBastet.Int.Subtractive;
+  include Bastet.Int.Subtractive;
 };
 
 module Divisive = {
-  include BsBastet.Int.Divisive;
+  include Bastet.Int.Divisive;
 };
 
 module Infix = {
-  include BsBastet.Int.Infix;
+  include Bastet.Int.Infix;
   include Relude_Extensions_Eq.EqInfix(Eq);
   include Relude_Extensions_Ord.OrdInfix(Ord);
 };

--- a/src/Relude_Interface.re
+++ b/src/Relude_Interface.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Module type signature for a type constructor with a single type hole.

--- a/src/Relude_Ior.re
+++ b/src/Relude_Ior.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_Map.re
+++ b/src/Relude_Map.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 type t('key, 'value, 'id) = Belt.Map.t('key, 'value, 'id);
 

--- a/src/Relude_NonEmpty.re
+++ b/src/Relude_NonEmpty.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Creates a NonEmpty module with the given SEQUENCE module to handle the tail part.

--- a/src/Relude_OptionT.re
+++ b/src/Relude_OptionT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Creates an OptionT monad with the given outer Monad

--- a/src/Relude_Ord.re
+++ b/src/Relude_Ord.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|

--- a/src/Relude_Ordering.re
+++ b/src/Relude_Ordering.re
@@ -9,7 +9,7 @@ for working with values of type [ordering].
 |}
 ];
 
-type t = BsBastet.Interface.ordering;
+type t = Bastet.Interface.ordering;
 
 /**
 [Ordering.fromInt] converts an int to a type-safe ordering value. This can be
@@ -49,7 +49,7 @@ let reverse: t => t =
 */
 let eq: (t, t) => bool = (a, b) => a == b;
 
-module Eq: BsBastet.Interface.EQ with type t = t = {
+module Eq: Bastet.Interface.EQ with type t = t = {
   type nonrec t = t;
   let eq = eq;
 };
@@ -73,7 +73,7 @@ let compare: (t, t) => t =
     | (`greater_than, `greater_than) => `equal_to
     };
 
-module Ord: BsBastet.Interface.ORD with type t = t = {
+module Ord: Bastet.Interface.ORD with type t = t = {
   include Eq;
   let compare = compare;
 };
@@ -83,7 +83,7 @@ let top = `greater_than;
 
 let bottom = `less_than;
 
-module Bounded: BsBastet.Interface.BOUNDED with type t = t = {
+module Bounded: Bastet.Interface.BOUNDED with type t = t = {
   include Ord;
   let top = top;
   let bottom = bottom;

--- a/src/Relude_RIO.re
+++ b/src/Relude_RIO.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 module WithError = (ERR: TYPE) => {

--- a/src/Relude_RWST.re
+++ b/src/Relude_RWST.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 module RWSResult = {
   type t('a, 's, 'w) =

--- a/src/Relude_ReaderT.re
+++ b/src/Relude_ReaderT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 // TODO: not sure whether to just make this functor include the "Env" type R here along with the Monad, or

--- a/src/Relude_Result.re
+++ b/src/Relude_Result.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 type t('a, 'e) = result('a, 'e) = | Ok('a) | Error('e);
@@ -909,7 +909,7 @@ let bimap = Bifunctor.bimap;
 include Relude_Extensions_Bifunctor.BifunctorExtensions(Bifunctor);
 
 module Bifoldable: BIFOLDABLE with type t('a, 'e) = t('a, 'e) = {
-  include BsBastet.Result.Bifoldable;
+  include Bastet.Result.Bifoldable;
 };
 let bifoldLeft = Bifoldable.bifold_left;
 let bifoldRight = Bifoldable.bifold_right;
@@ -991,7 +991,7 @@ module WithError = (E: TYPE) => {
   include Relude_Extensions_Semigroupoid.SemigroupoidExtensions(Semigroupoid);
 
   module Foldable: FOLDABLE with type t('a) = t('a) = {
-    include BsBastet.Result.Foldable(E);
+    include Bastet.Result.Foldable(E);
   };
   let foldLeft = Foldable.fold_left;
   let foldRight = Foldable.fold_right;
@@ -1001,7 +1001,7 @@ module WithError = (E: TYPE) => {
     module Traversable:
       TRAVERSABLE with
         type t('a) = t('a) and type applicative_t('a) = A.t('a) = {
-      include BsBastet.Result.Traversable(E, A);
+      include Bastet.Result.Traversable(E, A);
     };
     let traverse = Traversable.traverse;
     let sequence = Traversable.sequence;
@@ -1011,7 +1011,7 @@ module WithError = (E: TYPE) => {
       BITRAVERSABLE with
         type t('a, 'b) = result('a, 'b) and
         type applicative_t('a) = A.t('a) = {
-      include BsBastet.Result.Bitraversable(A);
+      include Bastet.Result.Bitraversable(A);
     };
     let bitraverse = Bitraversable.bitraverse;
     let bisequence = Bitraversable.bisequence;
@@ -1020,11 +1020,11 @@ module WithError = (E: TYPE) => {
             );
   };
 
-  module Eq = BsBastet.Result.Eq;
+  module Eq = Bastet.Result.Eq;
 
-  module Ord = BsBastet.Result.Ord;
+  module Ord = Bastet.Result.Ord;
 
-  module Show = BsBastet.Result.Show;
+  module Show = Bastet.Result.Show;
 
   module Infix = {
     include Relude_Extensions_Functor.FunctorInfix(Functor);

--- a/src/Relude_ResultT.re
+++ b/src/Relude_ResultT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Creates a ResultT Monad with the given outer Monad module.

--- a/src/Relude_Sequence.re
+++ b/src/Relude_Sequence.re
@@ -21,7 +21,7 @@ module List: Relude_Interface.SEQUENCE with type t('a) = list('a) = {
   let eqBy = Relude_List_Instances.eqBy;
   let showBy = Relude_List_Instances.showBy;
   let mkString =
-    Relude_List_Instances.intercalate((module BsBastet.String.Monoid));
+    Relude_List_Instances.intercalate((module Bastet.String.Monoid));
   module Functor = Relude_List_Instances.Functor;
   module Apply = Relude_List_Instances.Apply;
   module Applicative = Relude_List_Instances.Applicative;
@@ -55,7 +55,7 @@ module Array: Relude_Interface.SEQUENCE with type t('a) = array('a) = {
   let eqBy = Relude_Array_Instances.eqBy;
   let showBy = Relude_Array_Instances.showBy;
   let mkString =
-    Relude_Array_Instances.intercalate((module BsBastet.String.Monoid));
+    Relude_Array_Instances.intercalate((module Bastet.String.Monoid));
   module Functor = Relude_Array_Instances.Functor;
   module Apply = Relude_Array_Instances.Apply;
   module Applicative = Relude_Array_Instances.Applicative;

--- a/src/Relude_SequenceZipper.re
+++ b/src/Relude_SequenceZipper.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Creates a Zipper using the given SEQUENCE as the backing implementation.
@@ -208,7 +208,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
 
     module Fold_Map = (M: MONOID) => {
       module D =
-        BsBastet.Default.Fold_Map(
+        Bastet.Default.Fold_Map(
           M,
           {
             type nonrec t('a) = t('a);
@@ -219,7 +219,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
     };
     module Fold_Map_Any = (M: MONOID_ANY) => {
       module D =
-        BsBastet.Default.Fold_Map_Any(
+        Bastet.Default.Fold_Map_Any(
           M,
           {
             type nonrec t('a) = t('a);
@@ -230,7 +230,7 @@ module WithSequence = (S: Relude_Interface.SEQUENCE) => {
     };
     module Fold_Map_Plus = (P: PLUS) => {
       module D =
-        BsBastet.Default.Fold_Map_Plus(
+        Bastet.Default.Fold_Map_Plus(
           P,
           {
             type nonrec t('a) = t('a);

--- a/src/Relude_Set.re
+++ b/src/Relude_Set.re
@@ -347,7 +347,7 @@ module type SET = {
 };
 
 module WithOrd =
-       (M: BsBastet.Interface.ORD)
+       (M: Bastet.Interface.ORD)
        : (SET with type value = M.t and type Comparable.t = M.t) => {
   type value = M.t;
 

--- a/src/Relude_StateT.re
+++ b/src/Relude_StateT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 module WithMonad = (M: MONAD) => {

--- a/src/Relude_String.re
+++ b/src/Relude_String.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 type t = string;
 
@@ -425,7 +425,7 @@ include Relude_Extensions_Eq.EqExtensions(Eq);
 /**
 Compares two strings
 */
-let compare = BsBastet.String.Ord.compare;
+let compare = Bastet.String.Ord.compare;
 
 module Ord: ORD with type t = string = {
   include Eq;

--- a/src/Relude_Tree.re
+++ b/src/Relude_Tree.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 A non-empty multi-way (aka "rose") tree which contains a "top" value and

--- a/src/Relude_TreeZipper.re
+++ b/src/Relude_TreeZipper.re
@@ -585,7 +585,7 @@ let map: 'a 'b. ('a => 'b, t('a)) => t('b) =
     };
   };
 
-module Functor: BsBastet.Interface.FUNCTOR with type t('a) = t('a) = {
+module Functor: Bastet.Interface.FUNCTOR with type t('a) = t('a) = {
   type nonrec t('a) = t('a);
   let map = map;
 };

--- a/src/Relude_Tuple2.re
+++ b/src/Relude_Tuple2.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Constructs a tuple-2 from 2 values

--- a/src/Relude_Tuple3.re
+++ b/src/Relude_Tuple3.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Constructs a tuple-3 from 3 values

--- a/src/Relude_Tuple4.re
+++ b/src/Relude_Tuple4.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Constructs a tuple-4 from 4 values

--- a/src/Relude_Tuple5.re
+++ b/src/Relude_Tuple5.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Constructs a tuple-5 from 5 values

--- a/src/Relude_Unit.re
+++ b/src/Relude_Unit.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 type t = unit;
 

--- a/src/Relude_Validation.re
+++ b/src/Relude_Validation.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Similar to result, but has an Applicative instance that collects the errors

--- a/src/Relude_WriterT.re
+++ b/src/Relude_WriterT.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 [WriterLog] contains a basic typeclass that has a log type [t] and a Monoid

--- a/src/array/Relude_Array_Base.re
+++ b/src/array/Relude_Array_Base.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 [Array.cons] prepends a single item to the start of an array. This is an

--- a/src/array/Relude_Array_Instances.re
+++ b/src/array/Relude_Array_Instances.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Concatenates two arrays with the left side array first, and the right side last
@@ -14,7 +14,7 @@ include Relude_Extensions_SemigroupAny.SemigroupAnyExtensions(SemigroupAny);
 /**
 Applies a pure function to each value in the array
 */
-let map: 'a 'b. ('a => 'b, array('a)) => array('b) = BsBastet.Array.Functor.map;
+let map: 'a 'b. ('a => 'b, array('a)) => array('b) = Bastet.Array.Functor.map;
 
 module Functor: FUNCTOR with type t('a) = array('a) = {
   type t('a) = array('a);
@@ -25,7 +25,7 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
 /**
 Applies an array of functions to an array of values to produce a new array of values.
 */
-let apply: 'a 'b. (array('a => 'b), array('a)) => array('b) = BsBastet.Array.Apply.apply;
+let apply: 'a 'b. (array('a => 'b), array('a)) => array('b) = Bastet.Array.Apply.apply;
 
 module Apply: APPLY with type t('a) = array('a) = {
   include Functor;
@@ -47,7 +47,7 @@ include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 /**
 Maps a monadic function over each element of the array, and flattens (concatenates) the result.
 */
-let bind: 'a 'b. (array('a), 'a => array('b)) => array('b) = BsBastet.Array.Monad.flat_map;
+let bind: 'a 'b. (array('a), 'a => array('b)) => array('b) = Bastet.Array.Monad.flat_map;
 
 module Monad: MONAD with type t('a) = array('a) = {
   include Applicative;
@@ -58,7 +58,7 @@ include Relude_Extensions_Monad.MonadExtensions(Monad);
 /**
 Alt for arrays concatenates the two arrays
 */
-let alt: 'a. (array('a), array('a)) => array('a) = BsBastet.Array.Alt.alt;
+let alt: 'a. (array('a), array('a)) => array('a) = Bastet.Array.Alt.alt;
 
 module Alt: ALT with type t('a) = array('a) = {
   include Functor;
@@ -69,7 +69,7 @@ include Relude_Extensions_Alt.AltExtensions(Alt);
 /**
 Imap is the invariant map function for arrays.
 */
-let imap: 'a 'b. ('a => 'b, 'b => 'a, array('a)) => array('b) = BsBastet.Array.Invariant.imap;
+let imap: 'a 'b. ('a => 'b, 'b => 'a, array('a)) => array('b) = Bastet.Array.Invariant.imap;
 
 module Invariant: INVARIANT with type t('a) = array('a) = {
   type t('a) = array('a);
@@ -79,7 +79,7 @@ module Invariant: INVARIANT with type t('a) = array('a) = {
 /**
 Extend is the dual of the monadic bind function.
 */
-let extend: 'a 'b. (array('a) => 'b, array('a)) => array('b) = BsBastet.Array.Extend.extend;
+let extend: 'a 'b. (array('a) => 'b, array('a)) => array('b) = Bastet.Array.Extend.extend;
 
 module Extend: EXTEND with type t('a) = array('a) = {
   include Functor;
@@ -89,21 +89,21 @@ module Extend: EXTEND with type t('a) = array('a) = {
 /**
 Folds an array from left to right into an accumulator value
 */
-let foldLeft = BsBastet.Array.Foldable.fold_left;
+let foldLeft = Bastet.Array.Foldable.fold_left;
 
 /**
 Folds an array from right-to-left into an accumulator value
 */
-let foldRight = BsBastet.Array.Foldable.fold_right;
+let foldRight = Bastet.Array.Foldable.fold_right;
 
 module Foldable: FOLDABLE with type t('a) = array('a) = {
-  include BsBastet.Array.Foldable;
+  include Bastet.Array.Foldable;
   let fold_left = foldLeft;
   let fold_right = foldRight;
 };
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
-module Traversable = BsBastet.Array.Traversable;
+module Traversable = Bastet.Array.Traversable;
 
 /**
 Indicates if two arrays are pair-wise equal, using the given equality function
@@ -133,7 +133,7 @@ module Eq = (EqA: EQ) => {
   let eq = eqBy(EqA.eq);
 };
 
-module Ord = BsBastet.Array.Ord;
+module Ord = Bastet.Array.Ord;
 
 /**
 Converts an array to a string, using the given show function for converting the array items
@@ -141,7 +141,7 @@ Converts an array to a string, using the given show function for converting the 
 let showBy: 'a. ('a => string, array('a)) => string =
   (innerShow, xs) => {
     // TODO
-    let join = intercalate((module BsBastet.String.Monoid));
+    let join = intercalate((module Bastet.String.Monoid));
     "[" ++ join(", ", map(innerShow, xs)) ++ "]";
   };
 

--- a/src/array/Relude_Array_Specializations.re
+++ b/src/array/Relude_Array_Specializations.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Array extensions for when you have an EQ instance.

--- a/src/dune
+++ b/src/dune
@@ -1,12 +1,7 @@
-; (melange.emit
-;  (target output)
-;  (alias relude)
-;  (libraries
-;   melange
-;   bsBastet)
-;  (module_systems es6))
+(include_subdirs unqualified)
 
 (library
  (name relude)
  (public_name relude)
- (modes :standard melange))
+ (libraries bastet)
+ (modes melange))

--- a/src/extensions/Relude_Extensions_Alt.re
+++ b/src/extensions/Relude_Extensions_Alt.re
@@ -1,7 +1,7 @@
 /**
 Extensions for any ALT
 */
-module AltExtensions = (A: BsBastet.Interface.ALT) => {
+module AltExtensions = (A: Bastet.Interface.ALT) => {
   /**
   Alternative form of [alt] that uses a named argument for disambiguation
   */
@@ -14,7 +14,7 @@ module AltExtensions = (A: BsBastet.Interface.ALT) => {
 /**
 Infix operator extensions for any ALT
 */
-module AltInfix = (A: BsBastet.Interface.ALT) => {
+module AltInfix = (A: Bastet.Interface.ALT) => {
   /**
   Operator version for the [alt] function.
   */

--- a/src/extensions/Relude_Extensions_Alternative.re
+++ b/src/extensions/Relude_Extensions_Alternative.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any ALTERNATIVE
 */
-module AlternativeExtensions = (A: BsBastet.Interface.ALTERNATIVE) => {};
+module AlternativeExtensions = (A: Bastet.Interface.ALTERNATIVE) => {};

--- a/src/extensions/Relude_Extensions_Applicative.re
+++ b/src/extensions/Relude_Extensions_Applicative.re
@@ -1,8 +1,8 @@
 /**
 Extensions for any APPLICATIVE
 */
-module ApplicativeExtensions = (A: BsBastet.Interface.APPLICATIVE) => {
-  module BsApplicativeExtensions = BsBastet.Functions.Applicative(A);
+module ApplicativeExtensions = (A: Bastet.Interface.APPLICATIVE) => {
+  module BsApplicativeExtensions = Bastet.Functions.Applicative(A);
 
   /**
   Lifts a pure function ['a => 'b] into an applicative context

--- a/src/extensions/Relude_Extensions_Apply.re
+++ b/src/extensions/Relude_Extensions_Apply.re
@@ -1,8 +1,8 @@
 /**
 Extensions for any APPLY
 */
-module ApplyExtensions = (A: BsBastet.Interface.APPLY) => {
-  module BsApplyExtensions = BsBastet.Functions.Apply(A);
+module ApplyExtensions = (A: Bastet.Interface.APPLY) => {
+  module BsApplyExtensions = Bastet.Functions.Apply(A);
 
   /**
   Runs the two applicative effects, but only keeps the result from the left
@@ -135,7 +135,7 @@ module ApplyExtensions = (A: BsBastet.Interface.APPLY) => {
 /**
 Infix operator extensions for any APPLY
 */
-module ApplyInfix = (A: BsBastet.Interface.APPLY) => {
+module ApplyInfix = (A: Bastet.Interface.APPLY) => {
   module ApplyExtensions = ApplyExtensions(A);
 
   /**

--- a/src/extensions/Relude_Extensions_Bifoldable.re
+++ b/src/extensions/Relude_Extensions_Bifoldable.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any Bifoldable
 */
-module BifoldableExtensions = (B: BsBastet.Interface.BIFOLDABLE) => {};
+module BifoldableExtensions = (B: Bastet.Interface.BIFOLDABLE) => {};

--- a/src/extensions/Relude_Extensions_Bifunctor.re
+++ b/src/extensions/Relude_Extensions_Bifunctor.re
@@ -1,7 +1,7 @@
 /**
 Extensions for any Bifunctor
 */
-module BifunctorExtensions = (B: BsBastet.Interface.BIFUNCTOR) => {
+module BifunctorExtensions = (B: Bastet.Interface.BIFUNCTOR) => {
   /**
   Maps a function over the left-side type.
   */
@@ -26,7 +26,7 @@ module BifunctorExtensions = (B: BsBastet.Interface.BIFUNCTOR) => {
 /**
 Infix operator extensions for any BIFUNCTOR
 */
-module BifunctorInfix = (B: BsBastet.Interface.BIFUNCTOR) => {
+module BifunctorInfix = (B: Bastet.Interface.BIFUNCTOR) => {
   /**
   Operator version of bimap
   */

--- a/src/extensions/Relude_Extensions_Bitraversable.re
+++ b/src/extensions/Relude_Extensions_Bitraversable.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any BITRAVERSABLE
 */
-module BitraversableExtensions = (B: BsBastet.Interface.BITRAVERSABLE) => {};
+module BitraversableExtensions = (B: Bastet.Interface.BITRAVERSABLE) => {};

--- a/src/extensions/Relude_Extensions_Bounded.re
+++ b/src/extensions/Relude_Extensions_Bounded.re
@@ -1,1 +1,1 @@
-module BoundedExtensions = (B: BsBastet.Interface.BOUNDED) => {};
+module BoundedExtensions = (B: Bastet.Interface.BOUNDED) => {};

--- a/src/extensions/Relude_Extensions_BoundedEnum.re
+++ b/src/extensions/Relude_Extensions_BoundedEnum.re
@@ -95,10 +95,10 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
    */
   let inverseMapEq:
     type a.
-      (~eqA: (module BsBastet.Interface.EQ with type t = a), E.t => a, a) =>
+      (~eqA: (module Bastet.Interface.EQ with type t = a), E.t => a, a) =>
       option(E.t) =
     (~eqA, eToA) => {
-      let (module EqA) = (eqA: (module BsBastet.Interface.EQ with type t = a));
+      let (module EqA) = (eqA: (module Bastet.Interface.EQ with type t = a));
       inverseMapEqBy(EqA.eq, eToA);
     };
 
@@ -116,7 +116,7 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
    Running time for returned lookup function: O(log(n))
    */
   let inverseMapOrdBy:
-      type a. ((a, a) => BsBastet.Interface.ordering, E.t => a, a) => option(E.t) =
+      type a. ((a, a) => Bastet.Interface.ordering, E.t => a, a) => option(E.t) =
     (compareA, eToA) => {
       // Create the Map module used for doing lookups of a => E.t
       // This is necessary because of how OCaml maps work
@@ -157,11 +157,11 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
    */
   let inverseMapOrd:
     type a.
-      (~ordA: (module BsBastet.Interface.ORD with type t = a), E.t => a, a) =>
+      (~ordA: (module Bastet.Interface.ORD with type t = a), E.t => a, a) =>
       option(E.t) =
     (~ordA, eToA) => {
       let (module OrdA) = (
-        ordA: (module BsBastet.Interface.ORD with type t = a)
+        ordA: (module Bastet.Interface.ORD with type t = a)
       );
       inverseMapOrdBy(OrdA.compare, eToA);
     };
@@ -178,6 +178,6 @@ module BoundedEnumExtensions = (E: Relude_Interface.BOUNDED_ENUM) => {
    */
   let inverseMapString: (E.t => string, string) => option(E.t) =
     (eToString: E.t => string) => {
-      inverseMapOrdBy(BsBastet.String.Ord.compare, eToString)
+      inverseMapOrdBy(Bastet.String.Ord.compare, eToString)
     };
 };

--- a/src/extensions/Relude_Extensions_Comonad.re
+++ b/src/extensions/Relude_Extensions_Comonad.re
@@ -1,3 +1,3 @@
-module ComonadExtensions = (C: BsBastet.Interface.COMONAD) => {};
+module ComonadExtensions = (C: Bastet.Interface.COMONAD) => {};
 
-module ComonadInfix = (C: BsBastet.Interface.COMONAD) => {};
+module ComonadInfix = (C: Bastet.Interface.COMONAD) => {};

--- a/src/extensions/Relude_Extensions_Contravariant.re
+++ b/src/extensions/Relude_Extensions_Contravariant.re
@@ -1,3 +1,3 @@
-module ContravariantExtensions = (C: BsBastet.Interface.CONTRAVARIANT) => {};
+module ContravariantExtensions = (C: Bastet.Interface.CONTRAVARIANT) => {};
 
-module ContravariantInfix = (C: BsBastet.Interface.CONTRAVARIANT) => {};
+module ContravariantInfix = (C: Bastet.Interface.CONTRAVARIANT) => {};

--- a/src/extensions/Relude_Extensions_Eq.re
+++ b/src/extensions/Relude_Extensions_Eq.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Extensions for any EQ

--- a/src/extensions/Relude_Extensions_Extend.re
+++ b/src/extensions/Relude_Extensions_Extend.re
@@ -1,3 +1,3 @@
-module ExtendExtensions = (E: BsBastet.Interface.EXTEND) => {};
+module ExtendExtensions = (E: Bastet.Interface.EXTEND) => {};
 
-module ExtendInfix = (E: BsBastet.Interface.EXTEND) => {};
+module ExtendInfix = (E: Bastet.Interface.EXTEND) => {};

--- a/src/extensions/Relude_Extensions_Foldable.re
+++ b/src/extensions/Relude_Extensions_Foldable.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 [@ocaml.text
   {|
@@ -28,7 +28,7 @@ let optionAlt: (option('a), option('a)) => option('a) =
 Extensions for any FOLDABLE
 */
 module FoldableExtensions = (F: FOLDABLE) => {
-  module BsFoldableExtensions = BsBastet.Functions.Foldable(F);
+  module BsFoldableExtensions = Bastet.Functions.Foldable(F);
 
   /**
   Indicates if any item in the foldable satisfies the given predicate.

--- a/src/extensions/Relude_Extensions_Functor.re
+++ b/src/extensions/Relude_Extensions_Functor.re
@@ -1,8 +1,8 @@
 /**
 Extensions for any FUNCTOR
 */
-module FunctorExtensions = (F: BsBastet.Interface.FUNCTOR) => {
-  module BsFunctorExtensions = BsBastet.Functions.Functor(F);
+module FunctorExtensions = (F: Bastet.Interface.FUNCTOR) => {
+  module BsFunctorExtensions = Bastet.Functions.Functor(F);
 
   /**
   Flipped version of the map function which has the functor on the left, and the
@@ -37,7 +37,7 @@ module FunctorExtensions = (F: BsBastet.Interface.FUNCTOR) => {
 /**
 Infix operator extensions for any FUNCTOR
 */
-module FunctorInfix = (F: BsBastet.Interface.FUNCTOR) => {
+module FunctorInfix = (F: Bastet.Interface.FUNCTOR) => {
   module FunctorExtensions = FunctorExtensions(F);
 
   /**

--- a/src/extensions/Relude_Extensions_Monad.re
+++ b/src/extensions/Relude_Extensions_Monad.re
@@ -6,8 +6,8 @@ free" when you have a [Monad] typeclass instance.
 /**
 Extensions for any MONAD
 */
-module MonadExtensions = (M: BsBastet.Interface.MONAD) => {
-  module BsMonadExtensions = BsBastet.Functions.Monad(M);
+module MonadExtensions = (M: Bastet.Interface.MONAD) => {
+  module BsMonadExtensions = Bastet.Functions.Monad(M);
 
   /**
   Flipped version of [bind] which has the function on the left and the monad on
@@ -63,7 +63,7 @@ module MonadExtensions = (M: BsBastet.Interface.MONAD) => {
 /**
 Infix operator extensions for MONAD
 */
-module MonadInfix = (M: BsBastet.Interface.MONAD) => {
+module MonadInfix = (M: Bastet.Interface.MONAD) => {
   module MonadExtensions = MonadExtensions(M);
 
   /**

--- a/src/extensions/Relude_Extensions_Monoid.re
+++ b/src/extensions/Relude_Extensions_Monoid.re
@@ -1,8 +1,8 @@
 /**
 Extensions for any MONOID
 */
-module MonoidExtensions = (M: BsBastet.Interface.MONOID) => {
-  module BsMonoidExtensions = BsBastet.Functions.Monoid(M);
+module MonoidExtensions = (M: Bastet.Interface.MONOID) => {
+  module BsMonoidExtensions = Bastet.Functions.Monoid(M);
 
   /**
   Returns the monoidal value if the given condition is true, otherwise empty.

--- a/src/extensions/Relude_Extensions_MonoidAny.re
+++ b/src/extensions/Relude_Extensions_MonoidAny.re
@@ -1,7 +1,7 @@
 /**
 Extensions for any MONOID_ANY
 */
-module MonoidAnyExtensions = (M: BsBastet.Interface.MONOID_ANY) => {
+module MonoidAnyExtensions = (M: Bastet.Interface.MONOID_ANY) => {
   /**
   Returns the monoidal value if the given condition is true, otherwise empty.
   */

--- a/src/extensions/Relude_Extensions_Ord.re
+++ b/src/extensions/Relude_Extensions_Ord.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 [Extensions.Ord] is a module functor that accepts any [ORD]-compatible module

--- a/src/extensions/Relude_Extensions_Plus.re
+++ b/src/extensions/Relude_Extensions_Plus.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any PLUS
 */
-module PlusExtensions = (P: BsBastet.Interface.PLUS) => {};
+module PlusExtensions = (P: Bastet.Interface.PLUS) => {};

--- a/src/extensions/Relude_Extensions_Ring.re
+++ b/src/extensions/Relude_Extensions_Ring.re
@@ -1,7 +1,7 @@
 /**
 Extensions for any RING
 */
-module RingExtensions = (R: BsBastet.Interface.RING) => {
+module RingExtensions = (R: Bastet.Interface.RING) => {
   let (-) = R.subtract;
   let negate = v => R.zero - v;
 };

--- a/src/extensions/Relude_Extensions_Semigroup.re
+++ b/src/extensions/Relude_Extensions_Semigroup.re
@@ -1,13 +1,13 @@
 /**
 Extensions for any SEMIGROUP
 */
-module SemigroupExtensions = (S: BsBastet.Interface.SEMIGROUP) => {
+module SemigroupExtensions = (S: Bastet.Interface.SEMIGROUP) => {
   let concatNamed = (~prefix: S.t, suffix: S.t) => S.append(prefix, suffix);
 };
 
 /**
 Infix operator extensions for any SEMIGROUP
 */
-module SemigroupInfix = (S: BsBastet.Interface.SEMIGROUP) => {
+module SemigroupInfix = (S: Bastet.Interface.SEMIGROUP) => {
   let (|+|) = S.append;
 };

--- a/src/extensions/Relude_Extensions_SemigroupAny.re
+++ b/src/extensions/Relude_Extensions_SemigroupAny.re
@@ -1,7 +1,7 @@
 /**
 Extensions for any SEMIGROUP_ANY
 */
-module SemigroupAnyExtensions = (S: BsBastet.Interface.SEMIGROUP_ANY) => {
+module SemigroupAnyExtensions = (S: Bastet.Interface.SEMIGROUP_ANY) => {
   let concatNamed = (~prefix: S.t('a), suffix: S.t('a)): S.t('a) =>
     S.append(prefix, suffix);
 };
@@ -9,6 +9,6 @@ module SemigroupAnyExtensions = (S: BsBastet.Interface.SEMIGROUP_ANY) => {
 /**
 Infix operator extensions for any SEMIGROUP_ANY
 */
-module SemigroupAnyInfix = (S: BsBastet.Interface.SEMIGROUP_ANY) => {
+module SemigroupAnyInfix = (S: Bastet.Interface.SEMIGROUP_ANY) => {
   let (|+|) = S.append;
 };

--- a/src/extensions/Relude_Extensions_Semigroupoid.re
+++ b/src/extensions/Relude_Extensions_Semigroupoid.re
@@ -1,8 +1,8 @@
-module SemigroupoidExtensions = (S: BsBastet.Interface.SEMIGROUPOID) => {
+module SemigroupoidExtensions = (S: Bastet.Interface.SEMIGROUPOID) => {
   let andThen = (aToB, bToC) => S.compose(bToC, aToB);
 };
 
-module SemigroupoidInfix = (S: BsBastet.Interface.SEMIGROUPOID) => {
+module SemigroupoidInfix = (S: Bastet.Interface.SEMIGROUPOID) => {
   module SE = SemigroupoidExtensions(S);
   let (<<<) = S.compose;
   let (>>>) = SE.andThen;

--- a/src/extensions/Relude_Extensions_Semiring.re
+++ b/src/extensions/Relude_Extensions_Semiring.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any SEMIRING
 */
-module SemiringExtensions = (S: BsBastet.Interface.SEMIRING) => {};
+module SemiringExtensions = (S: Bastet.Interface.SEMIRING) => {};

--- a/src/extensions/Relude_Extensions_Show.re
+++ b/src/extensions/Relude_Extensions_Show.re
@@ -1,4 +1,4 @@
-module ShowExtensions = (S: BsBastet.Interface.SHOW) => {
+module ShowExtensions = (S: Bastet.Interface.SHOW) => {
   let logShow: S.t => unit = a => Js.log(S.show(a));
 
   let infoShow: S.t => unit = a => Js.Console.info(S.show(a));
@@ -8,4 +8,4 @@ module ShowExtensions = (S: BsBastet.Interface.SHOW) => {
   let errorShow: S.t => unit = a => Js.Console.error(S.show(a));
 };
 
-module ShowInfix = (S: BsBastet.Interface.SHOW) => {};
+module ShowInfix = (S: Bastet.Interface.SHOW) => {};

--- a/src/extensions/Relude_Extensions_Traversable.re
+++ b/src/extensions/Relude_Extensions_Traversable.re
@@ -1,4 +1,4 @@
 /**
 Extensions for any TRAVERSABLE
 */
-module TraversableExtensions = (T: BsBastet.Interface.TRAVERSABLE) => {};
+module TraversableExtensions = (T: Bastet.Interface.TRAVERSABLE) => {};

--- a/src/extensions/Relude_Extensions_Unfoldable.re
+++ b/src/extensions/Relude_Extensions_Unfoldable.re
@@ -1,3 +1,3 @@
-module UnfoldableExtensions = (U: BsBastet.Interface.UNFOLDABLE) => {};
+module UnfoldableExtensions = (U: Bastet.Interface.UNFOLDABLE) => {};
 
-module UnfoldableInfix = (U: BsBastet.Interface.UNFOLDABLE) => {};
+module UnfoldableInfix = (U: Bastet.Interface.UNFOLDABLE) => {};

--- a/src/js/Relude_Js_Json.re
+++ b/src/js/Relude_Js_Json.re
@@ -263,7 +263,7 @@ let toDictOfJsonOrEmpty: json => dict = toDictOfJsonOrElse(Js.Dict.empty());
 module Error = {
   type t = string;
 
-  module Type: BsBastet.Interface.TYPE with type t = t = {
+  module Type: Bastet.Interface.TYPE with type t = t = {
     type nonrec t = t;
   };
 };

--- a/src/list/Relude_List_Base.re
+++ b/src/list/Relude_List_Base.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 [List.cons] prepends the given item to the start of the given list. This

--- a/src/list/Relude_List_Instances.re
+++ b/src/list/Relude_List_Instances.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 Concatenates two lists with the left-side first and the right-side last.
@@ -26,7 +26,7 @@ include Relude_Extensions_MonoidAny.MonoidAnyExtensions(MonoidAny);
 /**
 Maps a pure function over a list
 */
-let map = BsBastet.List.Functor.map;
+let map = Bastet.List.Functor.map;
 
 module Functor: FUNCTOR with type t('a) = list('a) = {
   type t('a) = list('a);
@@ -37,7 +37,7 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
 /**
 Applies a list of functions to a list of values.
 */
-let apply = BsBastet.List.Apply.apply;
+let apply = Bastet.List.Apply.apply;
 
 module Apply: APPLY with type t('a) = list('a) = {
   include Functor;
@@ -48,7 +48,7 @@ include Relude_Extensions_Apply.ApplyExtensions(Apply);
 /**
 Lifts a single pure value into a list of one value.
 */
-let pure = BsBastet.List.Applicative.pure;
+let pure = Bastet.List.Applicative.pure;
 
 module Applicative: APPLICATIVE with type t('a) = list('a) = {
   include Apply;
@@ -59,7 +59,7 @@ include Relude_Extensions_Applicative.ApplicativeExtensions(Applicative);
 /**
 Maps a monadic function over a list of values and flattens the result.
 */
-let bind = BsBastet.List.Monad.flat_map;
+let bind = Bastet.List.Monad.flat_map;
 
 module Monad: MONAD with type t('a) = list('a) = {
   include Applicative;
@@ -70,7 +70,7 @@ include Relude_Extensions_Monad.MonadExtensions(Monad);
 /**
 alt for lists concatenates the lists.
 */
-let alt = BsBastet.List.Alt.alt;
+let alt = Bastet.List.Alt.alt;
 
 module Alt: ALT with type t('a) = list('a) = {
   include Functor;
@@ -95,15 +95,15 @@ include Relude_Extensions_Alternative.AlternativeExtensions(Alternative);
 /**
 Folds a list from left-to-right into a single value using an accumulator
 */
-let foldLeft = BsBastet.List.Foldable.fold_left;
+let foldLeft = Bastet.List.Foldable.fold_left;
 
 /**
 Folds a list from right-to-left into a single value using an accumulator
 */
-let foldRight = BsBastet.List.Foldable.fold_right;
+let foldRight = Bastet.List.Foldable.fold_right;
 
 module Foldable: FOLDABLE with type t('a) = list('a) = {
-  include BsBastet.List.Foldable;
+  include Bastet.List.Foldable;
   let fold_left = foldLeft;
   let fold_right = foldRight;
 };
@@ -112,15 +112,15 @@ include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 /**
 Create a list by recursively unfolding with a generator function and seed value
 */
-let unfold = BsBastet.List.Unfoldable.unfold;
+let unfold = Bastet.List.Unfoldable.unfold;
 
 module Unfoldable: UNFOLDABLE with type t('a) = list('a) = {
-  include BsBastet.List.Unfoldable;
+  include Bastet.List.Unfoldable;
   let unfold = unfold;
 };
 include Relude_Extensions_Unfoldable.UnfoldableExtensions(Unfoldable);
 
-module Traversable: BsBastet.List.TRAVERSABLE_F = BsBastet.List.Traversable;
+module Traversable: Bastet.List.TRAVERSABLE_F = Bastet.List.Traversable;
 
 /**
 Compares two lists for length and pair-wise equality using the given equality function
@@ -151,7 +151,7 @@ Converts a list to a string using the given show function
 */
 let showBy: ('a => string, list('a)) => string =
   (innerShow, xs) => {
-    let join = intercalate((module BsBastet.String.Monoid));
+    let join = intercalate((module Bastet.String.Monoid));
     "[" ++ join(", ", map(innerShow, xs)) ++ "]";
   };
 

--- a/src/list/Relude_List_Specializations.re
+++ b/src/list/Relude_List_Specializations.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 
 /**
 List extensions for when you have an EQ instance.
@@ -204,7 +204,7 @@ module Validation = {
   module Traversable = (Errors: SEMIGROUP_ANY, Error: TYPE) => {
     module ValidationE = Relude_Validation.WithErrors(Errors, Error);
     module ValidationEApplicative = ValidationE.Applicative;
-    include BsBastet.List.Traversable(ValidationEApplicative);
+    include Bastet.List.Traversable(ValidationEApplicative);
   };
 
   module TraversableWithErrorsAsList = (Error: TYPE) =>

--- a/src/option/Relude_Option_Instances.re
+++ b/src/option/Relude_Option_Instances.re
@@ -1,4 +1,4 @@
-open BsBastet.Interface;
+open Bastet.Interface;
 open Relude_Function.Infix;
 
 let compose:
@@ -53,7 +53,7 @@ include Relude_Extensions_Functor.FunctorExtensions(Functor);
   apply(None, None) == None;
 ]}
 */
-let apply: 'a 'b. (option('a => 'b), option('a)) => option('b) = BsBastet.Option.Apply.apply;
+let apply: 'a 'b. (option('a => 'b), option('a)) => option('b) = Bastet.Option.Apply.apply;
 
 module Apply: APPLY with type t('a) = option('a) = {
   include Functor;
@@ -153,7 +153,7 @@ If [opt] is [None], [foldLeft()] returns [accumulator].
 ]}
 */
 let foldLeft: 'a 'b. (('b, 'a) => 'b, 'b, option('a)) => 'b =
-  (fn, default) => BsBastet.Option.Foldable.fold_left(fn, default);
+  (fn, default) => Bastet.Option.Foldable.fold_left(fn, default);
 
 /**
 [foldRight(f, init, opt)] takes as its first argument a function [f]
@@ -172,9 +172,9 @@ If [opt] is [None], [foldLeft()] returns [accumulator].
 ]}
 */
 let foldRight: 'a 'b. (('a, 'b) => 'b, 'b, option('a)) => 'b =
-  (fn, default) => BsBastet.Option.Foldable.fold_right(fn, default);
+  (fn, default) => Bastet.Option.Foldable.fold_right(fn, default);
 
-module Foldable = BsBastet.Option.Foldable;
+module Foldable = Bastet.Option.Foldable;
 include Relude_Extensions_Foldable.FoldableExtensions(Foldable);
 
 /**
@@ -220,16 +220,16 @@ module Monoid_Any = {
   let empty = None;
 };
 
-module Alt = BsBastet.Option.Alt;
+module Alt = Bastet.Option.Alt;
 include Relude_Extensions_Alt.AltExtensions(Alt);
 
-module Plus = BsBastet.Option.Plus;
+module Plus = Bastet.Option.Plus;
 include Relude_Extensions_Plus.PlusExtensions(Plus);
 
-module Alternative = BsBastet.Option.Alternative;
+module Alternative = Bastet.Option.Alternative;
 include Relude_Extensions_Alternative.AlternativeExtensions(Alternative);
 
-module Traversable: BsBastet.Option.TRAVERSABLE_F = BsBastet.Option.Traversable;
+module Traversable: Bastet.Option.TRAVERSABLE_F = Bastet.Option.Traversable;
 
 /**
 In [eqBy(f, opt1, opt2)], [f] is a function that compares two arguments
@@ -288,17 +288,17 @@ let eq =
       fa2: option(a),
     )
     : bool => {
-  module Eq = BsBastet.Option.Eq((val showA));
+  module Eq = Bastet.Option.Eq((val showA));
   Eq.eq(fa1, fa2);
 };
 
-module Eq: BsBastet.Option.EQ_F =
+module Eq: Bastet.Option.EQ_F =
   (EqA: EQ) => {
     type t = option(EqA.t);
     let eq = (xs: t, ys: t) => eqBy(EqA.eq, xs, ys);
   };
 
-module Ord: BsBastet.Option.ORD_F = BsBastet.Option.Ord;
+module Ord: Bastet.Option.ORD_F = Bastet.Option.Ord;
 
 /**
 Converts the option to a string using the given show function
@@ -314,21 +314,21 @@ Converts the option to a string using the given SHOW module
 */
 let show =
     (type a, showA: (module SHOW with type t = a), fa: option(a)): string => {
-  module Show = BsBastet.Option.Show((val showA));
+  module Show = Bastet.Option.Show((val showA));
   Show.show(fa);
 };
 
-module Show = BsBastet.Option.Show;
+module Show = Bastet.Option.Show;
 
 module WithSemigroup = (S: SEMIGROUP) => {
-  module Semigroup = BsBastet.Option.Semigroup(S);
+  module Semigroup = Bastet.Option.Semigroup(S);
   include Relude_Extensions_Semigroup.SemigroupExtensions(Semigroup);
 
-  module Monoid = BsBastet.Option.Monoid(S);
+  module Monoid = Bastet.Option.Monoid(S);
   include Relude_Extensions_Monoid.MonoidExtensions(Monoid);
 };
 
 module WithApplicative = (A: APPLICATIVE) => {
-  module Traversable = BsBastet.Option.Traversable(A);
+  module Traversable = Bastet.Option.Traversable(A);
   include Relude_Extensions_Traversable.TraversableExtensions(Traversable);
 };

--- a/src/option/Relude_Option_Specializations.re
+++ b/src/option/Relude_Option_Specializations.re
@@ -1,9 +1,9 @@
-module OptionEqExtensions = (E: BsBastet.Interface.EQ) => {
+module OptionEqExtensions = (E: Bastet.Interface.EQ) => {
   let eq: (option(E.t), option(E.t)) => bool =
     Relude_Option_Instances.eqBy(E.eq);
 };
 
-module OptionOrdExtensions = (O: BsBastet.Interface.ORD) => {
+module OptionOrdExtensions = (O: Bastet.Interface.ORD) => {
   module OptionOrd = Relude_Option_Instances.Ord(O);
 
   let compare = OptionOrd.compare;
@@ -32,7 +32,7 @@ module IO = {
       Relude_IO.WithError({
         type t = e;
       });
-    module TraverseIO = BsBastet.Option.Traversable(IoE.Applicative);
+    module TraverseIO = Bastet.Option.Traversable(IoE.Applicative);
     TraverseIO.traverse(f, opt);
   };
 
@@ -43,7 +43,7 @@ module IO = {
       Relude_IO.WithError({
         type t = e;
       });
-    module TraverseIO = BsBastet.Option.Traversable(IoE.Applicative);
+    module TraverseIO = Bastet.Option.Traversable(IoE.Applicative);
     TraverseIO.sequence(opt);
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,7 +859,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bisect_ppx@^2.1.0, bisect_ppx@^2.7.1:
+bisect_ppx@^2.7.1:
   version "2.7.1"
   resolved "https://registry.npmjs.org/bisect_ppx/-/bisect_ppx-2.7.1.tgz"
   integrity sha512-e8gRgfhmCptiyGGov+54Acah+rc+svm0yc/26mn+M6CCNDADufVLMgRaG1uw3LAHm/PFPy+zGFAKMwd6lD2O2g==
@@ -924,18 +924,6 @@ browserslist@^4.20.2:
     escalade "^3.1.1"
     node-releases "^2.0.3"
     picocolors "^1.0.0"
-
-bs-bastet@jchavarri/bastet#melange:
-  version "2.0.0"
-  resolved "git+ssh://git@github.com/jchavarri/bastet.git#501134d7377d066542bc80bc3b56463e7af1ffdc"
-  dependencies:
-    bisect_ppx "^2.1.0"
-    bs-stdlib-shims "^0.1.0"
-
-bs-stdlib-shims@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/bs-stdlib-shims/-/bs-stdlib-shims-0.1.0.tgz"
-  integrity sha512-CszWow8iXOKgmzNCc5dR3kERaqzIp3f4nbV7lJF5vS9BHm70GqLlu7OBE/VCPKZ5noG1VtJAIVqIdLFqUdIRUQ==
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
- Consume `bastet` from opam
- Add `include_subdirs` in the relude library `dune` file so that modules in inner folders are picked up
- Replace usages of `BsBastet` with just `Bastet`

It seems relude doesn't consume any JS modules from `bastet.js` so that dependency wasn't added to the `dune` file.